### PR TITLE
restructure the site inner pages

### DIFF
--- a/_includes/cloud-me.md
+++ b/_includes/cloud-me.md
@@ -2,5 +2,5 @@
 
 Straight forward instructions for running on Amazon Web Services
 
-[OS<sup>v</sup> on EC2]({{ site.baseurl }}{% post_url /community/0000-01-25-amazon-ec2 %}){:.btn}
+[OS<sup>v</sup> on EC2]({{ site.baseurl }}{% post_url /started/0000-01-25-amazon-ec2 %}){:.btn}
 {:.introtext}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -46,9 +46,14 @@
         <div class="topMenu">
             <ul class="nav menu">
                 <li class="{% if page.url == '/index.html' %}current{% endif %}"><a href="{{ site.baseurl }}" >Home</a></li>
+		<!-- Nested loop is the only way to order the top nav menu base on a properity, in this case "order" -->
+		{% for order in (1..10) %}
                 {% for p in site.categories.top %}
+		{% if p.order == order %}
                 <li class="{% if page.url == p.url or page.nav and page.nav == p.nav %}current{% endif %}"><a href="{{ site.baseurl }}{{ p.url }}" >{{ p.title }}</a></li>
+		{% endif %}
                 {% endfor %}
+		{% endfor %}
             </ul>
         </div>
     </div>

--- a/_includes/run-me.md
+++ b/_includes/run-me.md
@@ -2,5 +2,5 @@
 
 Clone, Build, Execute and Relax
 
-[OS<sup>v</sup> on site]({{ site.baseurl }}{% post_url /community/0000-01-20-downloads %}){:.btn}
+[OS<sup>v</sup> on site]({{ site.baseurl }}{% post_url /started/0000-01-20-downloads %}){:.btn}
 {:.introtext}

--- a/_posts/0000-10-01-community.md
+++ b/_posts/0000-10-01-community.md
@@ -4,18 +4,23 @@ title: Community
 nav: community
 class: blog
 category: top
+order: 5
 ---
 
 {% for p in site.categories.community %}
-## {{ p.title }} ##
+{% if p.heading %}
+## {{ p.heading }}
 {:.section-header}
+{% else %}
+## {{ p.title }}
+{:.section-header}
+{% endif %}
 
 {{ p.excerpt }}
 
-{% if p.read_more %}
+{% if p.no_readmore != true %}
 [Read more...]({{site.baseurl}}{{ p.url }} "Read more")
 {:.readmore}
 {% endif %}
 - - -
 {% endfor %}
-

--- a/_posts/2014-02-10-getting-started.md
+++ b/_posts/2014-02-10-getting-started.md
@@ -1,12 +1,13 @@
 ---
 layout: nav
-title: Users
-nav: users
+title: Getting Started
+nav: started
 class: blog
 category: top
+order: 2
 ---
 
-{% for p in site.categories.users %}
+{% for p in site.categories.started %}
 {% if p.heading %}
 ## {{ p.heading }}
 {:.section-header}
@@ -23,4 +24,3 @@ category: top
 {% endif %}
 - - -
 {% endfor %}
-

--- a/_posts/2014-02-10-learn-more.md
+++ b/_posts/2014-02-10-learn-more.md
@@ -1,12 +1,13 @@
 ---
 layout: nav
-title: Development
-nav: dev
+title: Learn More
+nav: learn
 class: blog
 category: top
+order: 3
 ---
 
-{% for p in site.categories.dev %}
+{% for p in site.categories.learn %}
 {% if p.heading %}
 ## {{ p.heading }}
 {:.section-header}
@@ -23,4 +24,3 @@ category: top
 {% endif %}
 - - -
 {% endfor %}
-

--- a/_posts/community/0000-01-22-resources.markdown
+++ b/_posts/community/0000-01-22-resources.markdown
@@ -5,7 +5,7 @@ category: community
 nav: community
 show_heading: yes
 ---
-
+<!--more-->
 Mailing list: [osv-dev@googlegroups.com](mailto:osv-dev@googlegroups.com)
 
 Twitter: [@CloudiusSystems](https://twitter.com/CloudiusSystems)

--- a/_posts/community/0000-01-24-people.markdown
+++ b/_posts/community/0000-01-24-people.markdown
@@ -6,6 +6,9 @@ nav: community
 show_heading: yes
 ---
 
+Who is working on OSv?
+<!--more-->
+
 ## Within Cloudius Systems: ##
 
 * Amnon Heiman

--- a/_posts/community/0000-09-01-contact.md
+++ b/_posts/community/0000-09-01-contact.md
@@ -1,8 +1,15 @@
 ---
-layout: full-width
-title: Contact
-category: top
+layout: nav
+title: Contacts
+category: community
+nav: community
+show_heading: yes
 ---
+
+How to reach out for the OSv community?
+
+<!--more-->
+
 
 ![mailing list](images/envlope.jpg)|mailing list: [osv-dev@googlegroups.com](mailto:osv-dev@googlegroups.com)
 ![mailing list](images/birdy.jpg)|twitter: [@CloudiusSystems](http://twitter.com/CloudiusSystems)

--- a/_posts/community/0000-10-01-todo.md
+++ b/_posts/community/0000-10-01-todo.md
@@ -1,12 +1,14 @@
 ---
 layout: nav
 title: Todo
-category: dev
+category: community
 show_heading: yes
-nav: dev
+nav: community
 ---
 
+Want to help?
 We are working on the following directions in OSv:
+<!--more-->
 
 - Adding support for more hypervisors - we currently support Xen and KVM, but VMware is an important target for us
 

--- a/_posts/learn/0000-06-01-frequently-asked-questions.md
+++ b/_posts/learn/0000-06-01-frequently-asked-questions.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
 title: Frequently asked questions
-category: users
+category: learn
 show_heading: yes
-nav: users
+nav: learn
 ---
 
 ## Why a new operating system?

--- a/_posts/learn/0000-06-02-benchmarks.md
+++ b/_posts/learn/0000-06-02-benchmarks.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
 title: Benchmarks
-category: dev
+category: learn
 show_heading: yes
-nav: dev
+nav: learn
 heading: Spec JVM performance
 ---
 

--- a/_posts/learn/0000-06-03-design.md
+++ b/_posts/learn/0000-06-03-design.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
 title: Design
-category: dev
+category: learn
 show_heading: yes
-nav: dev
+nav: learn
 ---
 
 ## Virtual Memory

--- a/_posts/learn/0000-07-01-status.md
+++ b/_posts/learn/0000-07-01-status.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
 title: Status
-category: users
+category: learn
 show_heading: yes
-nav: users
+nav: learn
 ---
 
 As of today, Dec 31, 2013, OSv is already functional and capable of executing JVM and C code.

--- a/_posts/learn/0000-08-01-managebility.md
+++ b/_posts/learn/0000-08-01-managebility.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
 title: Managebility
-category: users
+category: learn
 show_heading: yes
-nav: users
+nav: learn
 ---
 
 ## Management usage and API:

--- a/_posts/learn/0000-08-01-user-cases.md
+++ b/_posts/learn/0000-08-01-user-cases.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
 title: Use Cases
-category: users
+category: learn
 show_heading: yes
-nav: users
+nav: learn
 ---
 
 ## Java application server (e.g. Tomcat)

--- a/_posts/learn/0000-09-01-what-is-osv.md
+++ b/_posts/learn/0000-09-01-what-is-osv.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
 title: What is OSv?
-category: users
+category: learn
 show_heading: yes
-nav: users
+nav: learn
 ---
 
 ## Unlike general purpose operating systems, OSv is designed to run a single application and tuned for JVMs.

--- a/_posts/learn/0000-10-01-technology.md
+++ b/_posts/learn/0000-10-01-technology.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
 title: Technology
-category: users
+category: learn
 show_heading: yes
-nav: users
+nav: learn
 ---
 
 ## The cloud design allows OSv to simplify the stack, both looking down (towards the hardware) and looking up (towards the application).

--- a/_posts/started/0000-01-20-downloads.md
+++ b/_posts/started/0000-01-20-downloads.md
@@ -1,8 +1,8 @@
 ---
 layout: nav
 title: Downloads
-category: community
-nav: community
+category: started
+nav: started
 show_heading: yes
 ---
 

--- a/_posts/started/0000-01-25-amazon-ec2.markdown
+++ b/_posts/started/0000-01-25-amazon-ec2.markdown
@@ -1,8 +1,8 @@
 ---
 layout: nav
-title: Amazon EC2
-category: community
-nav: community
+title: Run on Amazon EC2
+category: started
+nav: started
 show_heading: yes
 read_more: yes
 ---
@@ -10,4 +10,4 @@ Osv can run on top of AWS EC2. At the moment HVM mode only is enabled and suffer
 
 <!--more-->
 
-More information on how to run Osv on EC2 can be found here
+More information on how to run Osv on EC2 can be found here 

--- a/_posts/started/2014-02-10-run-locally.md
+++ b/_posts/started/2014-02-10-run-locally.md
@@ -1,8 +1,8 @@
 ---
 layout: nav
-title: Getting started
-category: community
-nav: community
+title: Run Locally
+category: started
+nav: started
 show_heading: yes
 read_more: yes
 ---

--- a/_posts/started/2014-02-10-why-new-os.md
+++ b/_posts/started/2014-02-10-why-new-os.md
@@ -1,19 +1,20 @@
 ---
 layout: nav
 title: Why New OS
-category: users
+category: started
 show_heading: yes
 heading: Why a whole new OS is required
-nav: users
+nav: started
 ---
 
-## It’s cloudy out there and we love it
+### It’s cloudy out there and we love it
 
-The public cloud era opens new horizons and opportunities for hi-tech businesses. Virtualization is dominant, resources are evergreen and agility is the key. The role of the OS in this form changes. The need to massively scale out forces developers to run multiple copies of identical Virtual Machines (VMs). VMs are the new process that needs to be lightweight, blazing fast, scalable and cheap. DevOps and PaaS solutions bypass the OS and allow developers to deploy their code directly to the cloud. All these goodies are rapidly penetrating the enterprise space with matching private cloud capabilities and virtual appliances that act as bridges to the public cloud
+The public cloud era opens new horizons and opportunities for hi-tech businesses. Virtualization is dominant, resources are evergreen and agility is the key. The role of the OS in this form changes. The need to massively scale out forces developers to run multiple copies of identical Virtual Machines (VMs). 
+<!--more-->
+VMs are the new process that needs to be lightweight, blazing fast, scalable and cheap. DevOps and PaaS solutions bypass the OS and allow developers to deploy their code directly to the cloud. All these goodies are rapidly penetrating the enterprise space with matching private cloud capabilities and virtual appliances that act as bridges to the public cloud
 
 ### Virtualization 2.0
 
-<!--more-->
 
 VMware had brought virtualization into the x86 world (recall that virtualization was introduced by IBM’s mainframes in the 70s). While VMware has done a fantastic job shifting the enterprise from physical to virtual, it stopped there. Amazon Web Services had wider vision; Amazon do not use terminology such as virtual machine. Amazon sees the entire user workload and solves scaling issues.
 

--- a/_posts/started/2014-02-11-intro.md
+++ b/_posts/started/2014-02-11-intro.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
-title: Users Intro
-category: users
+title: Intro
+category: started
 show_heading: yes
-nav: users
+nav: started
 ---
 
 Today’s cloud-based applications run a heavyweight stack: the hypervisor, which divides the hardware resources among virtual machines; the operating system, which divides the virtual machine’s resources among applications; and the application server, which divides the application’s resources among the end users.

--- a/dev/benchmark/index.html
+++ b/dev/benchmark/index.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: benchmarks
----

--- a/dev/design-submenu/index.html
+++ b/dev/design-submenu/index.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: design
----

--- a/dev/todo/index.html
+++ b/dev/todo/index.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: todo
----

--- a/users/freq-questions/index.html
+++ b/users/freq-questions/index.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: frequently-asked-questions
----

--- a/users/intro/index.html
+++ b/users/intro/index.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: users-intro
----
-

--- a/users/managebility/index.html
+++ b/users/managebility/index.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: managebility
----

--- a/users/status/index.html
+++ b/users/status/index.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: status
----
-

--- a/users/technology/index.html
+++ b/users/technology/index.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: technology
----

--- a/users/use-cases/index.html
+++ b/users/use-cases/index.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: use-cases
----

--- a/users/what-us-osv/index.html
+++ b/users/what-us-osv/index.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: what-is-osv
----

--- a/users/why-new-os/index.html
+++ b/users/why-new-os/index.html
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: why-new-os
----
-


### PR DESCRIPTION
Current site inner posts are categorized under Users, Development, Community
There is no relation between the post content and the category.

This pull requests fix that by creation more user friendly  categories: Getting Started, Learn More, Community
The goal was to update as little as possible in the post themselves.
A second (and third) iteration will be required to update the content and bring it up to date.
