### PR TITLE
update EC2 page

### DIFF
--- a/_posts/started/0000-01-25-amazon-ec2.markdown
+++ b/_posts/started/0000-01-25-amazon-ec2.markdown
@@ -10,4 +10,4 @@ Osv can run on top of AWS EC2. At the moment HVM mode only is enabled and suffer
 
 <!--more-->
 
-More information on how to run Osv on EC2 can be found here 
+More information on how to run Osv on EC2 can be found [here](https://github.com/cloudius-systems/osv/wiki/OSV-on-EC2)


### PR DESCRIPTION
Link to EC2 wiki was missing, now added.
