### PR TITLE
fix bug in CSS for body text

### DIFF
--- a/css/template.css
+++ b/css/template.css
@@ -9,7 +9,7 @@
 body {
 	font-family:Open Sans !important;
 	color:#232323;
-	font-style:15px;
+	font-size:15px;
 	Height: 100%;
 }
 a {


### PR DESCRIPTION
This bug made text and bullets on benchmark page to have different size.
