### PR TITLE
Remove robot-excluding meta tag

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html prefix="og: http://ogp.me/ns#" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb" dir="ltr">
 <head>
-    <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
     <base href="{{ site.baseurl }}/" />
     <link rel="stylesheet" type="text/css" href="css/template.css">
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Googlebot seems to be honoring this tag -- without it, it's more likely that the site will get crawled and indexed.
