### PR TITLE
Minor home page edits

### DIFF
--- a/_includes/design-for-the-cloud.md
+++ b/_includes/design-for-the-cloud.md
@@ -1,3 +1,3 @@
 ### Designed for the cloud
 
-OSv runs on top of unmodified KVM, Xen and Amazon EC2 (HVM only, debug mode).VMware support is planned in the near future. Public, private, enterprise virtualization and even developer's laptop, we'll support them all. Support for non x86 architectures is planned in the future.
+OS<sup>v</sup> runs on top of unmodified KVM, Xen and Amazon EC2 (HVM only, debug mode).VMware support is planned in the near future. Public, private, enterprise virtualization and even developer's laptop, we'll support them all. Support for non x86 architectures is planned in the future.

--- a/_includes/typical-cloud-stack.md
+++ b/_includes/typical-cloud-stack.md
@@ -1,5 +1,5 @@
 ### Typical cloud stack
 
-JVM, OS and and Hyper-visor - all provides protection and abstraction. OSv, minimize the redundancy between these layers.
+The JVM, OS and hypervisor all provide protection and abstraction. OS<sup>v</sup> minimizes the redundancy in these layers by simplifying the OS.
 
 ![app](images/app.jpg)

--- a/_includes/welcome.md
+++ b/_includes/welcome.md
@@ -1,3 +1,3 @@
-# Welcome to OS<sup>v</sup> [open source](https://github.com/cloudius-systems/osv) project - probably the best OS for cloud workloads!
+# Welcome to the OS<sup>v</sup> [open source](https://github.com/cloudius-systems/osv) project - probably the best OS for cloud workloads!
 
 ## OS<sup>v</sup> is designed from the ground up to execute a single application on top of a hypervisor, resulting in superior performance and effortless management

--- a/_posts/features/0000-07-01-optimize-native-apps.md
+++ b/_posts/features/0000-07-01-optimize-native-apps.md
@@ -3,15 +3,7 @@ category: feature
 title: Optimize your Native apps
 ---
 
-Usually OS<sup>v</sup> runs unmodified applications. In order to provide even better performance, it's possible to access low level kernel api.
+Usually OS<sup>v</sup> runs unmodified applications. In order to provide even better performance, it's possible to access a low level kernel api.
 
-An application have access to the block device and flushing, applications can map the NIC descriptors directly (virtio-app) and signal the hypervisor. We believe that the amount of cycles the application requires, should always be smaller than the kernel path.
-
-
-
-
-
-
-
-
+An application has access to the block device and flushing, and can map the NIC descriptors directly (virtio-app) and signal the hypervisor. We believe that the number of cycles the application requires should always be smaller than the kernel path.
 

--- a/_posts/features/0000-12-01-superior-performance.md
+++ b/_posts/features/0000-12-01-superior-performance.md
@@ -3,7 +3,5 @@ category: feature
 title: Superior Performance
 ---
 
-OS<sup>v</sup> reduces the memory and cpu overhead imposed by traditional OS. Scheduling is lightweight, the application and the kernel cooperate, memory pools are shared. It provides unparalleled short latencies and constant predictable performance, translated directly to capex saving by reduction of the number of OS instances/sizes.
-
-
+OS<sup>v</sup> reduces the memory and cpu overhead imposed by a traditional OS. Scheduling is lightweight, the application and the kernel cooperate, and memory pools are shared. OS<sup>v</sup> provides unparalleled short latencies and constant predictable performance, which translates directly to capex savings by reducing the size and number of OS instances.
 


### PR DESCRIPTION
- Add missing "sup" tags for the v in OSv
- Fix some inconsistent punctuation and usage
  (for example, hypervisor not hyper-visor)
