### PR TITLE
Remove link rel=canonical and links to missing RSS

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,9 +14,6 @@
     <meta name="keywords" content="osv, cloud, operating system">
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <title>{{ page.title }}</title>
-    <link href="community" rel="canonical" />
-    <link href="community?format=feed&amp;type=rss" rel="alternate" type="application/rss+xml" title="RSS 2.0" />
-    <link href="community?format=feed&amp;type=atom" rel="alternate" type="application/atom+xml" title="Atom 1.0" />
     <link href="favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
     <!--link rel="stylesheet" href="css/k2.css" type="text/css" /-->
     <!--script src="js/mootools-core.js" type="text/javascript"></script-->


### PR DESCRIPTION
Using a "canonical" URL does not seem to be necessary
here.  This link is useful for directing a search
engine to return the default version of a document
instead of showing "printer-friendly" or other
alternate versions.
