### PR TITLE
shorten the GCE post name so it would fit in the left menu

### DIFF
--- a/_posts/started/0000-01-26-gce.markdown
+++ b/_posts/started/0000-01-26-gce.markdown
@@ -1,6 +1,6 @@
 ---
 layout: nav
-title: Run on Google Compute Engine
+title: Run on Google GCE
 category: started
 nav: started
 show_heading: yes


### PR DESCRIPTION
fix #63
