### PR TITLE
move image download links to download page

### DIFF
--- a/_posts/learn/2014-04-07-alpha.md
+++ b/_posts/learn/2014-04-07-alpha.md
@@ -5,19 +5,6 @@ category: learn
 show_heading: yes
 nav: learn
 
-s3: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv/
-esx: .esx.ova
-gce: .gce.tar.gz
-qcow: .qemu.qcow2
-vbox: .vbox.ova
-vmw: .vmw.zip
-
-osv: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv/osv-v0.08
-tomcat: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv-tomcat/osv-tomcat-v0.08
-mem: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv-memcached-opt/osv-memcached-opt-v0.08
-iperf: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv-iperf/osv-iperf-v0.08
-cassandra: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv-cassandra/osv-cassandra-v0.08
-
 ---
 
 ## Alpha Release
@@ -123,21 +110,8 @@ already outperforms memcached on Linux by almost **300%** !
 More on memcached prototype and benchmark
 [here](https://github.com/cloudius-systems/osv/wiki/OSv-Case-Study:-Memcached)
 
-
-
 Other appliances do not outperform Linux guest by that much.
 Our plans is to boost their performance but the expected gain depends whether they are
 CPU or IO bound - improvement is expected for the second.
 
-## Available OSv Alpha Virtual Appliances:
-All images are available for direct download (click the V)
-
-Image                | OSv   |  OSv-Cassandra | OSv-Memcached | OSv-Tomcat | OSv-IPerf
----------------------|-------|----------------|---------------|------------|----------
-QCOW2 for KVM*       | [V]({{page.osv}}{{page.qcow}}) | [V]({{page.cassandra}}{{page.qcow}}) | [V]({{page.mem}}{{page.qcow}}) | [V]({{page.tomcat}}{{page.qcow}}) |  [V]({{page.iperf}}{{page.qcow}})
-OVA for VirtualBox*| [V]({{page.osv}}{{page.vbox}}) | [V]({{page.cassandra}}{{page.vbox}}) | [V]({{page.mem}}{{page.vbox}}) | [V]({{page.tomcat}}{{page.vbox}}) |  [V]({{page.iperf}}{{page.vbox}})
-VMW for VMWare workstation  | [V]({{page.osv}}{{page.vmw}}) | [V]({{page.cassandra}}{{page.vmw}}) | [V]({{page.mem}}{{page.vmw}}) | [V]({{page.tomcat}}{{page.vmw}}) |  [V]({{page.iperf}}{{page.vmw}})
-OVA for VMWare ESXi | [V]({{page.osv}}{{page.esx}}) | [V]({{page.cassandra}}{{page.esx}}) | [V]({{page.mem}}{{page.esx}}) | [V]({{page.tomcat}}{{page.esx}}) |  [V]({{page.iperf}}{{page.esx}})
-{:.supportTableB}
-
-\* Also available using Capstan search
+Download OSv Virtual Appliances [here](/downloads)

--- a/_posts/started/0000-01-20-downloads.md
+++ b/_posts/started/0000-01-20-downloads.md
@@ -4,12 +4,33 @@ title: Downloads
 category: started
 nav: started
 show_heading: yes
+
+s3: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv/
+esx: .esx.ova
+gce: .gce.tar.gz
+qcow: .qemu.qcow2
+vbox: .vbox.ova
+vmw: .vmw.zip
+
+osv: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv/osv-v0.08
+tomcat: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv-tomcat/osv-tomcat-v0.08
+mem: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv-memcached-opt/osv-memcached-opt-v0.08
+iperf: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv-iperf/osv-iperf-v0.08
+cassandra: http://downloads.osv.io.s3.amazonaws.com/cloudius/osv-cassandra/osv-cassandra-v0.08
+
 ---
 
 ### OSv Images
-Latest OSv ready to use images are available [here](https://github.com/cloudius-systems/osv/wiki#wiki-releases)
-Images are ready for execution on top of KVM using QCOW2 format       
+Easiest way to look for latest OSv images and run them is using [Capstan](/capstan)
 
-### Appliance Images
-Ready to use appliance for MemCacheD, Cassandra, Tomcat and more will be available soon.
-In the mean time, follow the instructions to build it your self [here](https://github.com/cloudius-systems/osv-apps)
+For OSv v0.08 images direct download see below
+
+Image                | OSv   |  OSv-Cassandra | OSv-Memcached | OSv-Tomcat | OSv-IPerf
+---------------------|-------|----------------|---------------|------------|----------
+QCOW2 for KVM*       | [V]({{page.osv}}{{page.qcow}}) | [V]({{page.cassandra}}{{page.qcow}}) | [V]({{page.mem}}{{page.qcow}}) | [V]({{page.tomcat}}{{page.qcow}}) |  [V]({{page.iperf}}{{page.qcow}})
+OVA for VirtualBox*| [V]({{page.osv}}{{page.vbox}}) | [V]({{page.cassandra}}{{page.vbox}}) | [V]({{page.mem}}{{page.vbox}}) | [V]({{page.tomcat}}{{page.vbox}}) |  [V]({{page.iperf}}{{page.vbox}})
+VMW for VMWare workstation  | [V]({{page.osv}}{{page.vmw}}) | [V]({{page.cassandra}}{{page.vmw}}) | [V]({{page.mem}}{{page.vmw}}) | [V]({{page.tomcat}}{{page.vmw}}) |  [V]({{page.iperf}}{{page.vmw}})
+OVA for VMWare ESXi | [V]({{page.osv}}{{page.esx}}) | [V]({{page.cassandra}}{{page.esx}}) | [V]({{page.mem}}{{page.esx}}) | [V]({{page.tomcat}}{{page.esx}}) |  [V]({{page.iperf}}{{page.esx}})
+{:.supportTableB}
+
+\* Also available using Capstan search


### PR DESCRIPTION
Image download table make more sense under download page than on the Alpha page
