### PR TITLE
replace image download table with a list

### DIFF
--- a/_posts/started/0000-01-20-downloads.md
+++ b/_posts/started/0000-01-20-downloads.md
@@ -25,12 +25,39 @@ Easiest way to look for latest OSv images and run them is using [Capstan](/capst
 
 For OSv v0.08 images direct download see below
 
-Image                | OSv   |  OSv-Cassandra | OSv-Memcached | OSv-Tomcat | OSv-IPerf
----------------------|-------|----------------|---------------|------------|----------
-QCOW2 for KVM*       | [V]({{page.osv}}{{page.qcow}}) | [V]({{page.cassandra}}{{page.qcow}}) | [V]({{page.mem}}{{page.qcow}}) | [V]({{page.tomcat}}{{page.qcow}}) |  [V]({{page.iperf}}{{page.qcow}})
-OVA for VirtualBox*| [V]({{page.osv}}{{page.vbox}}) | [V]({{page.cassandra}}{{page.vbox}}) | [V]({{page.mem}}{{page.vbox}}) | [V]({{page.tomcat}}{{page.vbox}}) |  [V]({{page.iperf}}{{page.vbox}})
-VMW for VMWare workstation  | [V]({{page.osv}}{{page.vmw}}) | [V]({{page.cassandra}}{{page.vmw}}) | [V]({{page.mem}}{{page.vmw}}) | [V]({{page.tomcat}}{{page.vmw}}) |  [V]({{page.iperf}}{{page.vmw}})
-OVA for VMWare ESXi | [V]({{page.osv}}{{page.esx}}) | [V]({{page.cassandra}}{{page.esx}}) | [V]({{page.mem}}{{page.esx}}) | [V]({{page.tomcat}}{{page.esx}}) |  [V]({{page.iperf}}{{page.esx}})
-{:.supportTableB}
+
+#### OSv with CLI
+* [Download]({{page.osv}}{{page.qcow}}) QCOW2 for KVM* 
+* [Download]({{page.osv}}{{page.vbox}}) OVA for VirtualBox*
+* [Download]({{page.osv}}{{page.vmw}}) VMW for VMWare workstation
+* [Download]({{page.osv}}{{page.esx}}) OVA for VMWare ESXi
+
+
+#### Cassandra Virtual Appliance
+* [Download]({{page.cassandra}}{{page.qcow}}) QCOW2 for KVM* 
+* [Download]({{page.cassandra}}{{page.vbox}}) OVA for VirtualBox*
+* [Download]({{page.cassandra}}{{page.vmw}}) VMW for VMWare workstation
+* [Download]({{page.cassandra}}{{page.esx}}) OVA for VMWare ESXi
+
+
+#### Memcached Virtual Appliance
+* [Download]({{page.mem}}{{page.qcow}}) QCOW2 for KVM* 
+* [Download]({{page.mem}}{{page.vbox}}) OVA for VirtualBox*
+* [Download]({{page.mem}}{{page.vmw}}) VMW for VMWare workstation
+* [Download]({{page.mem}}{{page.esx}}) OVA for VMWare ESXi
+
+
+#### Tomcat Virtual Appliance
+* [Download]({{page.tomcat}}{{page.qcow}}) QCOW2 for KVM* 
+* [Download]({{page.tomcat}}{{page.vbox}}) OVA for VirtualBox*
+* [Download]({{page.tomcat}}{{page.vmw}}) VMW for VMWare workstation
+* [Download]({{page.tomcat}}{{page.esx}}) OVA for VMWare ESXi
+
+
+#### IPerf Virtual Appliance
+* [Download]({{page.iperf}}{{page.qcow}}) QCOW2 for KVM* 
+* [Download]({{page.iperf}}{{page.vbox}}) OVA for VirtualBox*
+* [Download]({{page.iperf}}{{page.vmw}}) VMW for VMWare workstation
+* [Download]({{page.iperf}}{{page.esx}}) OVA for VMWare ESXi
 
 \* Also available using Capstan search


### PR DESCRIPTION
Fix #78
In the IL meetup, people commented the image download table is not clear.
It looks like a compatibility matrix, and it is easy to miss the V as a download link.
This fix remove the table in favor of an explicit list of images.
