### PR TITLE
update Capstan post to refer to local installation. 

### DIFF
--- a/_posts/started/2014-03-21-capstan.md
+++ b/_posts/started/2014-03-21-capstan.md
@@ -10,7 +10,11 @@ Capstan is a tool for rapidly building and running your application on OSv.  Cap
 
 If you haven't made your application available as a "virtual appliance" because of the complexity of doing it on a conventional OS, Capstan could be just what you need.  From fast horizontal scaling to demo and evaluation images, virtual appliance delivery of your application is now fast thanks to the low overhead of Capstan.
 
+## Install Capstan
+See **[here](/run-locally)**
+
 <!--more-->
+
 
 ## Running a Capstan-enabled application
 
@@ -22,13 +26,6 @@ locally for testing, under VirtualBox or KVM.
 ## See for yourself
 <script type="text/javascript" src="https://asciinema.org/a/8608.js"
 id="asciicast-8608" async data-speed="2" data-autoplay="1"></script>
-
-## Installation
-
-Capstan is written in Go and requires a Go environment. Installation instructions are in the [Capstan
-README](https://github.com/cloudius-systems/capstan/blob/master/README.md).
-
-Capstan runs on Linux and on Mac OS X. Although Capstan itself is cross-platform, if you are building a native OSv application using the Linux ABI, you will need to run the application's own build on Linux or in a cross-compilation environment.
 
 ## Capstan-enabling an application
 


### PR DESCRIPTION
This is a response to users problem in finding capstan installation instructions.
