### PR TITLE
add more links towards flashcache beta page

### DIFF
--- a/_posts/learn/2014-10-04-flashcache.md
+++ b/_posts/learn/2014-10-04-flashcache.md
@@ -1,9 +1,9 @@
 ---
 layout: nav
 title: Flashcache
-category: learn
 show_heading: yes
-nav: learn
+category: started
+nav: started
 ---
 
 As the name suggest, FlashCache is an extension of Memcached, enhanced to extend the storage capacity from RAM-only towards the SSD drive while preserving the performance

--- a/_posts/learn/2014-10-05-beta-registration.md
+++ b/_posts/learn/2014-10-05-beta-registration.md
@@ -6,6 +6,12 @@ show_heading: yes
 nav: learn
 ---
 
+If you are interested in Flashcache Beta program please
+[register to it here](flashcache)
+
+For other OSv Beta use cases see below
+
+
 ## Beta Program
 Thank you for applying for the OSv beta program.
 

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@ title: OSv - the operating system designed for the cloud
 	<p><b>Private beta program beginning now:</b> Get free early access to OS<sup>v</sup> virtual appliances, built for high performance and
 	extreme manageability.  <b><a href="/beta-release/">Learn&nbsp;more</a></b> or <b><a href="/beta-registration/">Sign&nbsp;up</a></b>.
 	</p>
+        <p>Learn more about <b><a href="/flashcache/">Flashcache beta</a></b></p>
 </div>
 
 <div class="clr"></div>


### PR DESCRIPTION
Flashcache registration got significantly less hits and applications than the generic beta one.
One reason is the lack of internal links to it.
This pull request try to improve that. 
